### PR TITLE
remove default value from text column

### DIFF
--- a/db/migrate/20131009153248_create_blogs.rb
+++ b/db/migrate/20131009153248_create_blogs.rb
@@ -3,7 +3,7 @@ class CreateBlogs < ActiveRecord::Migration
   def self.up
     create_table :blogs do |t|
       t.string :title,        limit:30,   null: false, default: "我的日志"
-      t.text :content,                    null: false, default: ""
+      t.text :content,                    null: false
       t.integer :user_id,                 null: false, default: ""
       t.string :tag
       t.timestamps

--- a/db/migrate/20140216140627_create_messages.rb
+++ b/db/migrate/20140216140627_create_messages.rb
@@ -2,7 +2,7 @@ class CreateMessages < ActiveRecord::Migration
   def change
     create_table :messages do |t|
       t.integer :user_id
-      t.text :content,                    null: false, default: ""
+      t.text :content,                    null: false
 
       t.timestamps
     end


### PR DESCRIPTION
When I clone the repo and run `bundle exec rake db:migrate`, I got the errors below:

```
Mysql2::Error: BLOB/TEXT column 'content' can't have a default value: CREATE TABLE `blogs` (`id` int(11) DEFAULT NULL auto_increment PRIMARY KEY, `title` varchar(30) DEFAULT '我的日志' NOT NULL, `content` text DEFAULT '' NOT NULL, `user_id` int(11) DEFAULT 0 NOT NULL, `tag` varchar(255), `created_at` datetime NOT NULL, `updated_at` datetime NOT NULL) ENGINE=InnoDB/Users/zhangyuan/code/My_blog/db/migrate/20131009153248_create_blogs.rb:4:in `up'
Tasks: TOP => db:migrate
(See full trace by running task with --trace)
```

MySQL Server version: 5.6.16 Homebrew
